### PR TITLE
Fall back to rcc-qt5 if qtchooser not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ UIC_PYTHON_FILES=$(patsubst data/%.ui,jabbercat/ui/%.py,$(UIC_SOURCE_FILES))
 
 RESOURCE_SOURCES=$(addprefix data/,$(shell xpath -e 'RCC/qresource/file/text()' data/resources.qrc 2>/dev/null))
 
+_RCC5!=which qtchooser 2>/dev/null && echo -run-tool=rcc -qt=5 || which rcc-qt5 2>/dev/null
+RCC5?=$(_RCC5)
+
 TS_FILES=$(wildcard translations/*.ts)
 
 TESTS?=tests/
@@ -24,7 +27,7 @@ $(UIC_PYTHON_FILES): jabbercat/ui/%.py: data/%.ui
 	$(BUILDUI) $< $@
 
 resources.rcc: data/resources.qrc $(RESOURCE_SOURCES)
-	cd data; qtchooser -run-tool=rcc -qt=5 --binary -o ../$@ resources.qrc
+	cd data; $(RCC5) --binary -o ../$@ resources.qrc
 
 docs-html:
 	cd docs; make html


### PR DESCRIPTION
This fixes the build on Arch (and probably others) and shouldn't break it on Debian et al.
I'm not sure how portable this is or what the recommended way is. However, it also lets you manually override the binary by setting the `RCC5` variable, eg.

    RCC5=mycustomrcclocation make

So it at least makes it possible to build elsewhere even if qtchooser and rcc-qt5 don't exist.