### PR TITLE
Silence echoing of echo commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ data/gemoji/db/emoji.json: data/gemoji
 
 data/js/emoji.json: data/emoji-java/src/main/resources/emojis.json data/gemoji/db/emoji.json
 	PYTHONPATH=. python3 utils/build-emojidb.py --emoji-java data/emoji-java/src/main/resources/emojis.json --gemoji data/gemoji/db/emoji.json "$@"
-	echo "that 'failed to load emoji database' you might‘ve just seen was "
-	echo "normal and NOT an error"
+	@echo "that 'failed to load emoji database' you might‘ve just seen was "
+	@echo "normal and NOT an error"
 
 
 debug-run: run-debug


### PR DESCRIPTION
Before:

```
failed to load emoji database
echo "that 'failed to load emoji database' you might‘ve just seen was "
that 'failed to load emoji database' you might‘ve just seen was
echo "normal and NOT an error"
normal and NOT an error
```

After:

```
failed to load emoji database
that 'failed to load emoji database' you might‘ve just seen was
normal and NOT an error
```